### PR TITLE
Fix missing pie-chart when UI requests data with the wrong file ID

### DIFF
--- a/imports/server/modules/data_proxy.ts
+++ b/imports/server/modules/data_proxy.ts
@@ -72,6 +72,12 @@ class DataProxy {
     public static request_file_data(fileId, fields, _id, delimiter='\t', headers=false): Observable<any>|any {
 
         let file = FilesUpload.findOne({_id: fileId});
+
+        if (!file) {
+            Log.error("Failed to find a file by id:", fileId);
+            return of({ error: true, message: `Failed to find a file by id ${fileId}`});
+        }
+
         const req_fields = fields.map((e) => (e.startsWith('$') ? e.slice(1)*1.0 : e*1.0) - 1);
 
         let clean = (x) => {
@@ -105,6 +111,7 @@ Meteor.startup( () => {
             switchMap( ({name, event, _id, fileId, data, delimiter }) =>
                 DataProxy.request_file_data(fileId, data, _id).pipe(map((d) => ({_id, data: d})))
             ),
+            filter((r: any) => !r.data.error),
             mergeMap((d) => DataProxy.master_data_update(d as any)),
             catchError((e) => of({ error: true, message: `Error: ${e}` }))
         )


### PR DESCRIPTION
If **function request_file_data** is called with the file ID that is missing in the **raw_data_files** collection on the satellite, the chain of observables stops on the first exception,  thus discarding all of the other events. Perhaps it's related to the mergeMap that is called right after the function that fails with exception. To prevent it, we need to check if the file is present in collection and in case of missing file, filter out event with error from the chain of observables.

This bug rarely appears because most of the times UI requests files based on IDs that he received from BioWardrobe-NG, so they are guaranteed to exist, unless some unexpected errors in BioWardrobe-NG.